### PR TITLE
BigQueryスキーマ対応とSlack通知Block Kit化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# HubSpot API使用状況まとめ
+
+## 使用しているHubSpot API
+
+### 1. Meetings API
+- **エンドポイント**: `GET /crm/v3/objects/meetings/{meetingId}`
+- **ファイル**: `src/clients/hubspotClient.ts:37`
+- **関数**: `fetchMeeting(meetingId: string)`
+- **取得プロパティ**: 
+  - `hs_meeting_start_time` (ミーティング開始時刻)
+  - `hs_meeting_end_time` (ミーティング終了時刻)
+- **関連**: `contacts` (関連するコンタクト情報)
+- **用途**: ミーティング詳細の取得とJST時刻への変換
+
+### 2. Contacts API
+- **エンドポイント**: `GET /crm/v3/objects/contacts/{contactId}`
+- **ファイル**: `src/clients/hubspotClient.ts:66`
+- **関数**: `fetchContact(contactId: string)`
+- **取得プロパティ**: 
+  - `selection_amenity_or_cleaning_or_both`
+  - `cleaning_spot`
+  - `cleaning_photo`
+  - `rule2`
+  - `recleaning_type`
+  - `sheets`
+  - `dubet`
+  - `bathtowl`
+  - `facetowl`
+  - `amenity`
+  - `request`
+  - `furniture_photo`
+  - `lastname`
+  - `firstname`
+  - `reservation_code`
+  - `email`
+  - `submission_id`
+  - `slack_thread`
+  - `listing_id`
+- **用途**: コンタクト詳細情報の取得
+
+## API設定
+- **ベースURL**: `https://api.hubapi.com`
+- **認証**: Bearer token (`HUBSPOT_API_TOKEN` 環境変数)
+- **HTTPクライアント**: axios
+
+## 使用フロー
+1. Webhookでミーティング作成を検知 (`src/handlers/webhookHandler.ts:24`)
+2. ミーティング詳細を取得 (`src/services/hubspotWebhookService.ts:10`)
+3. 関連コンタクト情報を取得 (`src/services/hubspotWebhookService.ts:14`)
+4. 取得したデータを使ってツアー作成・Slack通知・DB保存を実行

--- a/src/clients/dbClient.ts
+++ b/src/clients/dbClient.ts
@@ -21,8 +21,8 @@ export const saveToDatabase = async ({
   const conversion_date = formatDateToJSTString(nowJST);     // e.g., "2025-06-08 20:58:11"
 
   const row = {
-    agreement: contact.properties.rule ?? null,
-    desired_action: contact.properties.selection_amenity_or_cleaning_or_both ?? null,
+    agreement: contact.properties.rule2 ?? null,
+    desired_action: contact.properties.selection_amenity_or_cleaning_or_both2 ?? null,
     listing_id: contact.properties.listing_id ?? null,
     submission_id: contact.properties.submission_id ?? null,
     slack_thread: contact.properties.slack_thread ?? null,
@@ -33,8 +33,10 @@ export const saveToDatabase = async ({
     areas_recleaning: contact.properties.cleaning_spot ?? null,
     photo_of_areas_recleaning: contact.properties.cleaning_photo ?? null,
     recleaning_type: contact.properties.recleaning_type ?? null,
-    sheets: toInt(contact.properties.sheets),
-    duvet_cover: toInt(contact.properties.dubet),
+    bed_sheets: toInt(contact.properties.bed_sheets),
+    futon_sheets: toInt(contact.properties.futon_sheets),
+    bed_duvet: toInt(contact.properties.bed_duvet),
+    futon_duvet: toInt(contact.properties.futon_duvet),
     bath_towel: toInt(contact.properties.bathtowl),
     face_towel: toInt(contact.properties.facetowl),
     amenity: contact.properties.amenity ?? null,

--- a/src/clients/hubspotClient.ts
+++ b/src/clients/hubspotClient.ts
@@ -57,10 +57,53 @@ function formatToJSTString(isoString: string): string {
   
   
 
+
+
+// 複数のURL（セミコロン区切り）をハイパーリンク形式で返す
+function formatUrlsAsHyperlinks(urlString: string): string {
+  if (!urlString) return urlString;
+  
+  const urls = urlString.split(';').map(url => url.trim()).filter(url => url);
+  const hyperlinks: string[] = [];
+  
+  for (let i = 0; i < urls.length; i++) {
+    // Slackのハイパーリンク形式: <URL|表示テキスト>
+    hyperlinks.push(`<${urls[i]}|写真${i + 1}>`);
+  }
+  
+  return hyperlinks.join('\n');
+}
+
+// 複数回答（セミコロン区切り）を箇条書き形式にフォーマット
+function formatMultipleAnswers(answerString: string): string {
+  if (!answerString) return answerString;
+  
+  const answers = answerString.split(';').map(answer => answer.trim()).filter(answer => answer);
+  
+  if (answers.length <= 1) {
+    return answerString; // 単一回答の場合はそのまま返す
+  }
+  
+  return answers.map(answer => `• ${answer}`).join('\n');
+}
+
+// アメニティ用: セミコロン区切りを「/」区切りの横並びにフォーマット
+function formatAmenityAsSlashSeparated(answerString: string): string {
+  if (!answerString) return answerString;
+  
+  const answers = answerString.split(';').map(answer => answer.trim()).filter(answer => answer);
+  
+  if (answers.length <= 1) {
+    return answerString; // 単一回答の場合はそのまま返す
+  }
+  
+  return answers.join(' / ');
+}
+
 export async function fetchContact(contactId: string) {
   const properties = [
-    'selection_amenity_or_cleaning_or_both','cleaning_spot','cleaning_photo','rule',
-    'recleaning_type','sheets','dubet','bathtowl','facetowl','amenity','request',
+    'selection_amenity_or_cleaning_or_both2','cleaning_spot','cleaning_photo','rule2',
+    'recleaning_type','bed_sheets','futon_sheets','bed_duvet','futon_duvet','bathtowl','facetowl','amenity','request',
     'furniture_photo','lastname','firstname','reservation_code','email','submission_id','slack_thread','listing_id']
 
   const url = `${BASE_URL}/crm/v3/objects/contacts/${contactId}`;
@@ -68,5 +111,52 @@ export async function fetchContact(contactId: string) {
     headers: { Authorization: `Bearer ${token}` },
     params: { properties: properties.join(',') },
   });
-  return res.data;
+  
+  const contact = res.data;
+  
+  // HubSpot Contact API 生レスポンス全体をログ出力
+  console.log('🔍 [HubSpot Contact API] 完全レスポンス:');
+  console.log(JSON.stringify(contact, null, 2));
+  
+  // デバッグ: 変換前の生データをログ出力
+  console.log('📋 [fetchContact] 変換前データ:');
+  console.log('   cleaning_photo:', contact.properties.cleaning_photo);
+  console.log('   furniture_photo:', contact.properties.furniture_photo);
+  console.log('   selection_amenity_or_cleaning_or_both2:', contact.properties.selection_amenity_or_cleaning_or_both2);
+  console.log('   amenity:', contact.properties.amenity);
+  
+  // cleaning_photo と furniture_photo をハイパーリンク形式に変換
+  if (contact.properties.cleaning_photo) {
+    console.log('📷 cleaning_photo (変換前):', contact.properties.cleaning_photo);
+    contact.properties.cleaning_photo = formatUrlsAsHyperlinks(contact.properties.cleaning_photo);
+    console.log('📷 cleaning_photo (ハイパーリンク変換後):', contact.properties.cleaning_photo);
+  }
+  
+  if (contact.properties.furniture_photo) {
+    console.log('🖼️ furniture_photo (変換前):', contact.properties.furniture_photo);
+    contact.properties.furniture_photo = formatUrlsAsHyperlinks(contact.properties.furniture_photo);
+    console.log('🖼️ furniture_photo (ハイパーリンク変換後):', contact.properties.furniture_photo);
+  }
+  
+  // selection_amenity_or_cleaning_or_both2 を箇条書き形式にフォーマット
+  if (contact.properties.selection_amenity_or_cleaning_or_both2) {
+    console.log('🔄 selection_amenity_or_cleaning_or_both2フォーマット開始...');
+    const originalValue = contact.properties.selection_amenity_or_cleaning_or_both2;
+    contact.properties.selection_amenity_or_cleaning_or_both2 = formatMultipleAnswers(contact.properties.selection_amenity_or_cleaning_or_both2);
+    console.log('✅ selection_amenity_or_cleaning_or_both2フォーマット完了:');
+    console.log('   変換前:', originalValue);
+    console.log('   変換後:', contact.properties.selection_amenity_or_cleaning_or_both2);
+  }
+  
+  // amenity を「/」区切りの横並び形式にフォーマット
+  if (contact.properties.amenity) {
+    console.log('🔄 amenityフォーマット開始...');
+    const originalValue = contact.properties.amenity;
+    contact.properties.amenity = formatAmenityAsSlashSeparated(contact.properties.amenity);
+    console.log('✅ amenityフォーマット完了:');
+    console.log('   変換前:', originalValue);
+    console.log('   変換後:', contact.properties.amenity);
+  }
+  
+  return contact;
 }

--- a/src/clients/m2mClient.ts
+++ b/src/clients/m2mClient.ts
@@ -8,8 +8,10 @@ const M2M_CREATE_TOUR_URL  = 'https://api-cleaning.m2msystems.cloud/v3/cleanings
 
 const { M2M_EMAIL, M2M_PASSWORD } = process.env;
 
-const DEFAULT_CLEANER_IDS   = ['f9afe0ee-424e-4eb8-b294-ae9ff20d4257']; // ✅ 本番用 ID に戻す
-const DEFAULT_PHOTO_TOUR_ID = '9f5af4d1-412f-4951-9692-061c698711b4';
+const DEFAULT_CLEANER_IDS   = [`f9afe0ee-424e-4eb8-b294-ae9ff20d4257`]//[''4afd3785-5ae8-452f-b35f-d7df7db79674]; // ✅ 本番用 ID に戻す
+const DEFAULT_PHOTO_TOUR_ID = '9a60b231-a33a-465b-81fd-0be268c19ec2' // 本番用ID
+//'9f5af4d1-412f-4951-9692-061c698711b4' PoC用ID;
+
 
 export const makingTour = async (contact: Contact): Promise<string> => {
   /* ===== ① ログイン ===== */

--- a/src/clients/slackClient.ts
+++ b/src/clients/slackClient.ts
@@ -2,8 +2,8 @@ import { ContactResponse as Contact }  from '../types/hubspot';
 import { MeetingResponse as Meeting }  from '../types/hubspot';
 
 const SLACK_TOKEN   = process.env.SLACK_TOKEN!;
-const SLACK_CHANNEL_ID               = 'CDMDK9V96'; // TODO: 本番に差し替え
-const SLACK_CHANNEL_FOR_NOTIFICATION = 'C08PD3ZNWHY'; // TODO: 本番に差し替え
+const SLACK_CHANNEL_ID               =  'CDMDK9V96'//''C08F1E5BP9U; // TODO: 本番に差し替え
+const SLACK_CHANNEL_FOR_NOTIFICATION = 'C08PD3ZNWHY'//C08F1E5BP9U'C08PD3ZNWHY'; // TODO: 本番に差し替え
 
 /* ------------------------------------------------------------------ */
 /* 1) メイン通知                                                      */
@@ -17,8 +17,8 @@ export const sendSlackMessage = async (
   /* ---------- 文面を組み立て ---------- */
   const success = !!cleaningId;    // null / undefined / '' をすべて失敗扱い
   const head    = success
-    ? '✅ ツアーを作成しました！'
-    : `❌ ツアー作成に失敗しました\n\`${error?.message ?? 'unknown error'}\``;
+    ? '✅ ゲストがフォームに回答しました！✅'
+    : `💀 ゲストがフォームに回答しましたが、ツアーの作成に失敗しました💀`;
 
   const cleaningUrlAdmin   = success
     ? `https://manager-cleaning.m2msystems.cloud/operations/${cleaningId}`
@@ -27,45 +27,223 @@ export const sendSlackMessage = async (
     ? `https://cleaner-cleaning.m2msystems.cloud/operations/${cleaningId}`
     : '—';
 
-    const text = `
-    <!subteam^S05NVPXMSNP>
-    ${head}
-    
-    👤 *ゲスト情報*
-    - 予約コード: ${contact.properties.reservation_code ?? '不明'} 
-    - Submission-ID: ${contact.properties.submission_id ?? '不明'} 
-    - 物件 ID: ${contact.properties.listing_id ?? '不明'} 
-    - 名前: ${contact.properties.firstname ?? '不明'} ${contact.properties.lastname ?? ''}
-    - メール: ${contact.properties.email ?? '未設定'}
-    
-    ✋ *希望する対応*
-    - 希望する対応: ${contact.properties.selection_amenity_or_cleaning_or_both ?? '未設定'}
-    - 再清掃箇所: ${contact.properties.cleaning_spot ?? '未設定'}
-    - 再清掃箇所の写真: ${contact.properties.cleaning_photo ?? '未設定'}
-    - 同意事項: ${contact.properties.rule ?? '未設定'}
-    - 希望する再清掃実施方法: ${contact.properties.recleaning_type ?? '未設定'}
-    - リネン枚数: ${contact.properties.sheets ?? '未設定'}
-    - 掛け布団カバー枚数: ${contact.properties.dubet ?? '未設定'}
-    - バスタオル枚数: ${contact.properties.bathtowl ?? '未設定'}
-    - フェイスタオル枚数: ${contact.properties.facetowl ?? '未設定'}
-    - 希望するアメニティ: ${contact.properties.amenity ?? '未設定'}
-    - その他配送希望物品: ${contact.properties.request ?? '未設定'}
-    - 交換希望物品写真: ${contact.properties.furniture_photo ?? '未設定'}
-    
-    📅 *到着希望時間*
-    - 開始: ${meeting.properties.hs_meeting_start_time_jst}
-    - 終了: ${meeting.properties.hs_meeting_end_time_jst}
-    
-    🔗 *M2M 管理画面リンク*
-    - 管理者画面: ${cleaningUrlAdmin}
-    - Cleaner 画面: ${cleaningUrlCleaner}
-    `;
+  const fallbackText = `<!subteam^S05NVPXMSNP> ${head}`;
 
-  /* ---------- Slack 送信 ---------- */
+  /* ---------- Block Kit payload 構築 ---------- */
   const payload: Record<string, unknown> = {
     channel: SLACK_CHANNEL_ID,
-    text,
+    text: fallbackText,
+    attachments: [
+      {
+        color: success ? "#2eb886" : "#ff6b6b",
+        title: "フォーム回答",
+        text: `ステータス: ${success ? '受付済み' : 'エラー'}`
+      }
+    ],
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: head, emoji: true }
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `<!subteam^S05NVPXMSNP>\n以下の回答内容を確認して、対応項目を実施してください🏃` }
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*・対応項目*" }
+      },
+      {
+        type: "rich_text",
+        elements: [
+          {
+            type: "rich_text_list",
+            style: "ordered",
+            elements: success ? [
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "\"OP-配送-サポート便\"ツアーを作成" }]
+              },
+              {
+                type: "rich_text_section", 
+                elements: [{ type: "text", text: "時間を設定する" }]
+              },
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "アサインする" }]
+              },
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "ドライバーに連絡" }]
+              }
+            ] : [
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "\"OP-トラブル-サポート便\"ツアーを作成し、taskチームをアサインする" }]
+              },
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "\"OP-配送-サポート便\"ツアーを作成" }]
+              },
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "時間を設定する" }]
+              },
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "アサインする" }]
+              },
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "ドライバーに連絡" }]
+              }
+            ]
+          }
+        ]
+      },
+      { type: "divider" },
+
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*👤 ゲスト情報*" }
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅予約コード*\n${contact.properties.reservation_code ?? '不明'}` },
+          { type: "mrkdwn", text: `*🔅Submission-ID*\n${contact.properties.submission_id ?? '不明'}` }
+        ]
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅物件ID*\n${contact.properties.listing_id ?? '不明'}` },
+          { type: "mrkdwn", text: `*🔅姓名*\n${contact.properties.firstname ?? '不明'} ${contact.properties.lastname ?? ''}` }
+        ]
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅メールアドレス*\n<mailto:${contact.properties.email ?? 'none'}|${contact.properties.email ?? '未設定'}>` },
+          { type: "mrkdwn", text: `*🔅Contact-ID*\n${contact.id ?? '不明'}` }
+        ]
+      },
+
+      { type: "divider" },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*✋ 希望する対応*" }
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅対応内容*\n${contact.properties.selection_amenity_or_cleaning_or_both2 ?? '未設定'}` },
+          { type: "mrkdwn", text: `*🔅到着希望時間*\n開始: ${meeting.properties.hs_meeting_start_time_jst}\n終了: ${meeting.properties.hs_meeting_end_time_jst}` }
+        ]
+      },
+
+      { type: "divider" },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*🧹 再清掃希望詳細*" }
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅再清掃箇所*\n${contact.properties.cleaning_spot ?? '未設定'}` },
+          { type: "mrkdwn", text: `*🔅同意事項*\n${contact.properties.rule2 ?? '未設定'}` }
+        ]
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅再清掃箇所の写真*\n${contact.properties.cleaning_photo ?? '未設定'}` },
+          { type: "mrkdwn", text: `*🔅再清掃実施方法*\n${contact.properties.recleaning_type ?? '未設定'}` }
+        ]
+      },
+
+      { type: "divider" },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*🛌 アメニティ不備希望詳細*" }
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅シーツ枚数(ベッド用)*\n${contact.properties.bed_sheets ?? '未設定'}` },
+          { type: "mrkdwn", text: `*🔅シーツ枚数(布団用)*\n${contact.properties.futon_sheets ?? '未設定'}` }
+        ]
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅掛け布団カバー枚数(ベッド・2段ベッド用)*\n${contact.properties.bed_duvet ?? '未設定'}` },
+          { type: "mrkdwn", text: `*🔅布団掛け布団カバー枚数(布団用)*\n${contact.properties.futon_duvet ?? '未設定'}` }
+        ]
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅バスタオル枚数*\n${contact.properties.bathtowl ?? '未設定'}` },
+          { type: "mrkdwn", text: `*🔅フェイスタオル枚数*\n${contact.properties.facetowl ?? '未設定'}` }
+        ]
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅アメニティ類*\n${contact.properties.amenity ?? '未設定'}` }
+        ]
+      },
+
+      { type: "divider" },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*🏃 その他希望詳細*" }
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅その他配送希望物品*\n${contact.properties.request ?? '未設定'}` },
+          { type: "mrkdwn", text: `*🔅交換希望物品写真*\n${contact.properties.furniture_photo ?? '未設定'}` }
+        ]
+      },
+
+      { type: "divider" },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*👩‍💻 m2mへのURL*" }
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: success ? `*🔅管理者画面*\n<${cleaningUrlAdmin}|リンク>` : `*🔅管理者画面*\n作成失敗` },
+          { type: "mrkdwn", text: success ? `*🔅Cleaner 画面*\n<${cleaningUrlCleaner}|リンク>` : `*🔅Cleaner 画面*\n作成失敗` }
+        ]
+      }
+    ]
   };
+
+  // アクションボタンは成功時のみ追加
+  if (success) {
+    (payload.blocks as any[]).push({
+      type: "actions",
+      elements: [
+        { type: "button", text: { type: "plain_text", text: "管理者画面を開く" }, url: cleaningUrlAdmin },
+        { type: "button", text: { type: "plain_text", text: "Cleaner画面を開く" }, url: cleaningUrlCleaner }
+      ]
+    });
+  }
+
+  // エラー詳細を表示する場合
+  if (!success && error) {
+    (payload.blocks as any[]).push(
+      { type: "divider" },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*❌ エラー詳細*\n\`\`\`${error?.message ?? 'unknown error'}\`\`\`` }
+      }
+    );
+  }
 
   const threadTs = contact.properties.slack_thread;
   if (threadTs) payload.thread_ts = threadTs;   // ts があるときだけスレッド化
@@ -86,17 +264,109 @@ export const sendSlackMessage = async (
 /* ------------------------------------------------------------------ */
 /* 2) 汎用ワンショット通知                                            */
 /* ------------------------------------------------------------------ */
-export const sendSlackNotification = async (text: string) => {
+export const sendSlackNotification = async (
+  contact: Contact,
+  _meeting: Meeting,
+  error: any,
+  _contactId: string
+) => {
+  // メイン通知と同じBlock Kit形式のペイロードを作成
+  const head = '💀 ゲストがフォームに回答しましたが、ツアーの作成に失敗しました💀';
+  
+  const payload = {
+    channel: SLACK_CHANNEL_FOR_NOTIFICATION,
+    text: "エラー通知",
+    attachments: [
+      {
+        color: "#ff6b6b",
+        title: "フォーム回答",
+        text: "ステータス: エラー"
+      }
+    ],
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: head, emoji: true }
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `<!subteam^S05NVPXMSNP>\n以下の回答内容を確認して、対応項目を実施してください🏃` }
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*・対応項目*" }
+      },
+      {
+        type: "rich_text",
+        elements: [
+          {
+            type: "rich_text_list",
+            style: "ordered",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "\"OP-トラブル-サポート便\"ツアーを作成し、taskチームをアサインする" }]
+              },
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "\"OP-配送-サポート便\"ツアーを作成" }]
+              },
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "時間を設定する" }]
+              },
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "アサインする" }]
+              },
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "ドライバーに連絡" }]
+              }
+            ]
+          }
+        ]
+      },
+      { type: "divider" },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*⚠️ エラー詳細*\n\`${error?.message ?? 'unknown error'}\`` }
+      },
+      { type: "divider" },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*👤 ゲスト情報*" }
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅予約コード*\n${contact.properties.reservation_code ?? '未設定'}` },
+          { type: "mrkdwn", text: `*🔅Submission-ID*\n${contact.properties.submission_id ?? '未設定'}` }
+        ]
+      },
+      {
+        type: "section", 
+        fields: [
+          { type: "mrkdwn", text: `*🔅物件ID*\n${contact.properties.listing_id ?? '未設定'}` },
+          { type: "mrkdwn", text: `*🔅姓名*\n${contact.properties.lastname ?? ''} ${contact.properties.firstname ?? ''}` }
+        ]
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*🔅メールアドレス*\n<mailto:${contact.properties.email ?? ''}|${contact.properties.email ?? '未設定'}>` }
+        ]
+      }
+    ]
+  };
+
   const res = await fetch('https://slack.com/api/chat.postMessage', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${SLACK_TOKEN}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      channel: SLACK_CHANNEL_FOR_NOTIFICATION,
-      text,
-    }),
+    body: JSON.stringify(payload),
   });
 
   const data = await res.json();

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,5 @@ app.post('/webhook', handleWebhook);
 const port = process.env.PORT || 8080;
 app.listen(port, () => {
   console.log(`Server is running on port ${port}`);
+  console.log(`Webhook endpoint: /webhook`);
 });

--- a/src/services/hubspotWebhookService.ts
+++ b/src/services/hubspotWebhookService.ts
@@ -30,20 +30,8 @@ export const processWebhook = async (objectId: string) => {
   // sendSlackMessage のシグネチャ:
   // (contact, meeting, cleaningId: string | null, error?: any)
   if (tourError) {
-    /* 失敗時は別チャンネルにも詳細を飛ばす --------------- */
-    const errorMessage = `
-  <!subteam^S05NVPXMSNP>
-  ❌ ツアー作成に失敗しました
-  \`${tourError?.message ?? 'unknown error'}\`
-  
-  👤 *ゲスト情報*
-  - Contact-ID : ${contact.id ?? contactId ?? '不明'}
-  - 予約コード : ${contact.properties.reservation_code  ?? '不明'}
-  - Submission-ID : ${contact.properties.submission_id    ?? '不明'}
-  - 物件 ID     : ${contact.properties.listing_id       ?? '不明'}
-  `;
-  
-    await sendSlackNotification(errorMessage.trim());
+    /* 失敗時は別チャンネルにも詳細なBlock Kit形式で送信 */
+    await sendSlackNotification(contact, meeting, tourError, contactId);
   }
 
   /* ---------- ④ DB 保存 ---------- */

--- a/src/types/hubspot.ts
+++ b/src/types/hubspot.ts
@@ -19,13 +19,15 @@ export interface MeetingResponse {
   export interface ContactResponse {
     id: string;
     properties: {
-      selection_amenity_or_cleaning_or_both?: string;
+      selection_amenity_or_cleaning_or_both2?: string;
       cleaning_spot?: string;
       cleaning_photo?: string | null;
-      rule?: string;
+      rule2?: string;
       recleaning_type?: string;
-      sheets?: string;
-      dubet?: string;
+      bed_sheets?: string;
+      futon_sheets?: string;
+      bed_duvet?: string;
+      futon_duvet?: string;
       bathtowl?: string;
       facetowl?: string;
       amenity?: string;


### PR DESCRIPTION
## Summary
- BigQueryテーブル用のbed_sheets, futon_sheets, bed_duvet, futon_duvet カラムに対応
- HubSpotプロパティ名をrule2, selection_amenity_or_cleaning_or_both2に更新  
- Slack通知をBlock Kit形式にリニューアル（視認性向上）
- 写真URLのハイパーリンク化とアメニティの横並び表示機能追加
- エラー通知もBlock Kit形式で統一

## Test plan
- [ ] BigQueryへの保存が正常に動作することを確認
- [ ] Slack通知がBlock Kit形式で正しく表示されることを確認
- [ ] エラー時の通知も適切に送信されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)